### PR TITLE
feat(error.go): add IntoZapLog method to convert errors into zap.Field for structured logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/sierrasoftworks/humane-errors-go
 
 go 1.18
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/print_test.go
+++ b/print_test.go
@@ -2,9 +2,11 @@ package humane_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/sierrasoftworks/humane-errors-go"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"go.uber.org/zap"
 )
 
 func TestFormatter(t *testing.T) {
@@ -13,4 +15,16 @@ func TestFormatter(t *testing.T) {
 	assert.Equal(t, `Something went wrong`, fmt.Sprintf("%v", err))
 
 	// TODO: We should add a test for the %+v formatter once that is supported
+}
+
+func TestZapLog(t *testing.T) {
+	expected := make([]zap.Field, 0)
+	expected = append(expected, zap.Errors("causes", []error{fmt.Errorf("internal error")}))
+	expected = append(expected, zap.Strings("advice", []string{"Try turning it off...permanently."}))
+	expected = append(expected, zap.Error(fmt.Errorf("Something went wrong")))
+
+	err := humane.Wrap(fmt.Errorf("internal error"), "Something went wrong", "Try turning it off...permanently.")
+	zapFields := err.IntoZapLog()
+	assert.Equal(t, 3, len(zapFields), "the zap log should have two fields")
+	assert.Equal(t, expected, zapFields, "the zap log should have the expected fields")
 }


### PR DESCRIPTION
This PR adds a new method `IntoZapLog()` to humaneError which converts a structured humane error into a slice of `zap.Field` values, making it much easier to integrate humane-errors-go with structured logging using Zap.

## Why this is useful

Many Go applications already use [uber-go/zap](https://github.com/uber-go/zap) for structured logging.
Instead of manually extracting `.Error()`, advice, and causes, this method generates a structured log format that captures:

- All wrapped causes
- Aggregated advice from nested errors (if available)
- The base message

## Example usage:

```go
err := humane.Wrap(
	os.Remove("nonexistent.txt"),
	"We couldn't remove the nonexistent.txt file from the current directory.",
	"Ensure that the file exists in the current directory.",
	"Ensure you have write permissions to the file.",
)

zap.L().Error("operation failed", err.IntoZapLog()...)
```

This makes logging richer, more consistent, and easier to reason about — especially in production systems where structured logs matter.