### PR TITLE
feat: add Newf, Wrapf constructors with functional options pattern

### DIFF
--- a/error.go
+++ b/error.go
@@ -63,18 +63,75 @@ type humaneError struct {
 	cause   error
 }
 
-// The New method constructs a humane error without a defined cause.
+// Option is a functional option that configures a humane error
+// created with [Newf] or [Wrapf]. Options provide a flexible,
+// extensible way to attach metadata such as advice to an error.
+type Option interface {
+	apply(*humaneError)
+}
+
+type adviceOption struct {
+	advice []string
+}
+
+func (o *adviceOption) apply(e *humaneError) {
+	e.advice = append(e.advice, o.advice...)
+}
+
+// WithAdvice returns an [Option] that attaches one or more pieces of advice
+// to a humane error. Multiple pieces of advice can be provided in a single
+// call, and multiple WithAdvice options will append to the error's advice list.
+func WithAdvice(advice ...string) Option {
+	return &adviceOption{advice: advice}
+}
+
+// parseArgs separates format arguments from Options in a mixed variadic slice.
+func parseArgs(args []any) (fmtArgs []any, opts []Option) {
+	for _, a := range args {
+		if o, ok := a.(Option); ok {
+			opts = append(opts, o)
+		} else {
+			fmtArgs = append(fmtArgs, a)
+		}
+	}
+	return
+}
+
+// applyOptions applies a slice of Options to a humaneError.
+func applyOptions(e *humaneError, opts []Option) {
+	for _, o := range opts {
+		o.apply(e)
+	}
+}
+
+// New constructs a humane error without a defined cause.
 // It is commonly used when creating an initial error, in contrast
-// to the `Wrap` method which is used to wrap an existing error.
+// to [Wrap] which is used to wrap an existing error.
 func New(message string, advice ...string) Error {
 	return &humaneError{message, advice, nil}
 }
 
-// The Wrap method constructs a human error which wraps an existing error.
-// It is commonly used when another error has resulted in something that should
-// be bubbled up to the user to handle.
-// If `nil` is provided as the cause, this method will return `nil` as well,
-// allowing it to safely wrap optional errors and currying their presence correctly.
+// Newf constructs a humane error with a formatted message and functional options.
+// Format arguments and [Option] values can be freely intermixed in the variadic
+// args; any argument implementing [Option] is extracted and applied to the error,
+// while the remaining arguments are passed to [fmt.Sprintf] along with the
+// format string.
+func Newf(format string, args ...any) Error {
+	fmtArgs, opts := parseArgs(args)
+
+	e := &humaneError{
+		message: fmt.Sprintf(format, fmtArgs...),
+	}
+	applyOptions(e, opts)
+
+	return e
+}
+
+// Wrap constructs a humane error which wraps an existing error.
+// It is commonly used when another error has resulted in something that
+// should be bubbled up to the user to handle.
+// If nil is provided as the cause, this function will return nil as well,
+// allowing it to safely wrap optional errors and curry their presence correctly.
 func Wrap(cause error, message string, advice ...string) Error {
 	if cause == nil {
 		return nil
@@ -83,8 +140,32 @@ func Wrap(cause error, message string, advice ...string) Error {
 	return &humaneError{message, advice, cause}
 }
 
-// The Display method implements Go's `error` interface and returns a templated
-// error message describing what a user may do to respond to the issue.
+// Wrapf constructs a humane error which wraps an existing error, with a
+// formatted message and functional options. Format arguments and [Option]
+// values can be freely intermixed in the variadic args; any argument
+// implementing [Option] is extracted and applied to the error, while the
+// remaining arguments are passed to [fmt.Sprintf] along with the format string.
+// If nil is provided as the cause, this function will return nil as well,
+// allowing it to safely wrap optional errors and curry their presence correctly.
+func Wrapf(cause error, format string, args ...any) Error {
+	if cause == nil {
+		return nil
+	}
+
+	fmtArgs, opts := parseArgs(args)
+
+	e := &humaneError{
+		message: fmt.Sprintf(format, fmtArgs...),
+		cause:   cause,
+	}
+	applyOptions(e, opts)
+
+	return e
+}
+
+// Display returns a structured error string which provides the user with
+// advice on how best to respond, along with information about the underlying
+// cause of the error.
 func (e *humaneError) Display() string {
 	b := bytes.NewBufferString("")
 

--- a/error_test.go
+++ b/error_test.go
@@ -47,6 +47,110 @@ This was caused by:
  - This code is broken`, err.Display())
 }
 
+func TestNewf(t *testing.T) {
+	err := humane.Newf("failed to resolve user %s", "alice@example.com",
+		humane.WithAdvice("ensure the user exists"),
+	)
+
+	assert.Equal(t, "failed to resolve user alice@example.com", err.Error())
+	assert.Equal(t, []string{"ensure the user exists"}, err.Advice())
+	assert.Nil(t, err.Cause())
+}
+
+func TestNewfNoFormatArgs(t *testing.T) {
+	err := humane.Newf("static message",
+		humane.WithAdvice("some advice"),
+	)
+
+	assert.Equal(t, "static message", err.Error())
+	assert.Equal(t, []string{"some advice"}, err.Advice())
+}
+
+func TestNewfMultipleFormatArgs(t *testing.T) {
+	err := humane.Newf("user %s has %d items", "alice", 42,
+		humane.WithAdvice("check inventory"),
+	)
+
+	assert.Equal(t, "user alice has 42 items", err.Error())
+}
+
+func TestNewfNoOptions(t *testing.T) {
+	err := humane.Newf("failed to resolve user %s", "alice@example.com")
+
+	assert.Equal(t, "failed to resolve user alice@example.com", err.Error())
+	assert.Empty(t, err.Advice())
+	assert.Nil(t, err.Cause())
+}
+
+func TestNewfMultipleWithAdvice(t *testing.T) {
+	err := humane.Newf("something failed",
+		humane.WithAdvice("first advice"),
+		humane.WithAdvice("second advice"),
+	)
+
+	assert.Equal(t, []string{"first advice", "second advice"}, err.Advice())
+}
+
+func TestNewfVariadicWithAdvice(t *testing.T) {
+	err := humane.Newf("something failed",
+		humane.WithAdvice("advice 1", "advice 2"),
+	)
+
+	assert.Equal(t, []string{"advice 1", "advice 2"}, err.Advice())
+}
+
+func TestNewfMixedWithAdvice(t *testing.T) {
+	err := humane.Newf("something failed",
+		humane.WithAdvice("advice 1", "advice 2"),
+		humane.WithAdvice("advice 3"),
+	)
+
+	assert.Equal(t, []string{"advice 1", "advice 2", "advice 3"}, err.Advice())
+}
+
+func TestWrapfNilCause(t *testing.T) {
+	err := humane.Wrapf(nil, "failed to resolve %s", "alice")
+	assert.Nil(t, err, "wrapf with nil cause should return nil")
+}
+
+func TestWrapf(t *testing.T) {
+	cause := fmt.Errorf("connection refused")
+	err := humane.Wrapf(cause, "failed to connect to %s:%d", "localhost", 5432,
+		humane.WithAdvice("check that the database is running"),
+	)
+
+	assert.Equal(t, "failed to connect to localhost:5432", err.Error())
+	assert.Equal(t, []string{"check that the database is running"}, err.Advice())
+	assert.Equal(t, cause, err.Cause())
+}
+
+func TestWrapfDisplay(t *testing.T) {
+	cause := fmt.Errorf("connection refused")
+	err := humane.Wrapf(cause, "failed to connect to %s", "database",
+		humane.WithAdvice("check that the database is running"),
+		humane.WithAdvice("verify your connection string"),
+	)
+
+	assert.Equal(t, `failed to connect to database
+
+To fix this, you can try:
+ - check that the database is running
+ - verify your connection string
+
+This was caused by:
+ - connection refused`, err.Display())
+}
+
+func TestWrapfErrorIs(t *testing.T) {
+	base := fmt.Errorf("base error")
+	err := humane.Wrapf(base, "wrapped %s", "error",
+		humane.WithAdvice("some advice"),
+	)
+
+	assert.True(t, errors.Is(err, base), "wrapf error should be equivalent to the base error")
+	assert.True(t, errors.Is(err, fmt.Errorf("wrapped error")), "wrapf error should be equivalent to an error with the same message")
+}
+
 func TestErrorIs(t *testing.T) {
 	base := fmt.Errorf("base error")
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package humane_test
 
 import (
+	"fmt"
 	"github.com/sierrasoftworks/humane-errors-go"
 	"os"
 )
@@ -28,4 +29,67 @@ func ExampleError() {
 	// This was caused by:
 	//  - remove nonexistent.txt: no such file or directory
 	//  - no such file or directory
+}
+
+// This example demonstrates creating a new humane error with a formatted
+// message and advice using functional options.
+func ExampleNewf() {
+	email := "alice@example.com"
+
+	err := humane.Newf("failed to resolve user %s", email,
+		humane.WithAdvice("ensure the user exists in the directory"),
+		humane.WithAdvice("check that the email address is spelled correctly"),
+	)
+
+	humane.Print(err)
+
+	// Output:
+	// failed to resolve user alice@example.com
+	//
+	// To fix this, you can try:
+	//  - ensure the user exists in the directory
+	//  - check that the email address is spelled correctly
+}
+
+// This example demonstrates wrapping an existing error with a formatted
+// message and advice using functional options.
+func ExampleWrapf() {
+	cause := fmt.Errorf("connection refused")
+
+	err := humane.Wrapf(cause, "failed to connect to %s on port %d", "db.example.com", 5432,
+		humane.WithAdvice("check that the database server is running"),
+		humane.WithAdvice("verify your connection string is correct"),
+	)
+
+	humane.Print(err)
+
+	// Output:
+	// failed to connect to db.example.com on port 5432
+	//
+	// To fix this, you can try:
+	//  - check that the database server is running
+	//  - verify your connection string is correct
+	//
+	// This was caused by:
+	//  - connection refused
+}
+
+// This example demonstrates providing multiple pieces of advice
+// in a single WithAdvice call.
+func ExampleWithAdvice() {
+	err := humane.Newf("configuration file not found",
+		humane.WithAdvice(
+			"create a config.yaml file in the current directory",
+			"run the init command to generate a default configuration",
+		),
+	)
+
+	humane.Print(err)
+
+	// Output:
+	// configuration file not found
+	//
+	// To fix this, you can try:
+	//  - create a config.yaml file in the current directory
+	//  - run the init command to generate a default configuration
 }


### PR DESCRIPTION
## Motivation

The existing `New` and `Wrap` constructors use variadic strings for advice, which means you can't combine format strings with advice in a single call. Since humane error messages are user-facing and almost always include contextual details, this leads to a lot of `fmt.Sprintf` wrapping:

```go
// Before: fmt.Sprintf wrapping gets noisy
humane.Wrap(err, fmt.Sprintf("failed to resolve user %s", email), "ensure the user exists")
```

## What this adds

Two new constructors, `Newf` and `Wrapf`, that accept a format string followed by a mix of format arguments and functional options:

```go
// After: format string and options in one call
humane.Newf("failed to resolve user %s", email,
    humane.WithAdvice("ensure the user exists"),
)

humane.Wrapf(err, "failed to connect to %s on port %d", host, port,
    humane.WithAdvice("check that the database is running"),
    humane.WithAdvice("verify your connection string"),
)
```

Format args and `Option` values are separated by type assertion at runtime, similar to how some structured logging libraries handle mixed argument lists. Anything implementing the `Option` interface is extracted and applied to the error, everything else goes to `fmt.Sprintf`.

## Backward compatibility

The existing API is untouched. `New`, `Wrap`, and all their behavior (including nil-currying on `Wrap`) remain exactly as they are. This is a purely additive change, no migration required.

## New API surface

| Symbol | Description |
|--------|-------------|
| `Option` | Interface for functional options (unexported `apply` method, so only this package can define options) |
| `WithAdvice(advice ...string)` | Attaches advice to an error. Variadic, and multiple calls append. |
| `Newf(format string, args ...any)` | Creates an error with a formatted message and options |
| `Wrapf(cause error, format string, args ...any)` | Wraps an error with a formatted message and options. Returns nil if cause is nil. |

## Other changes

Doc comments across the package were cleaned up for Go conventions: function names instead of "The X method", fixed the `Display()` comment that incorrectly said it implements the `error` interface, and corrected a "human error" typo. Testable `Example` functions were added for `Newf`, `Wrapf`, and `WithAdvice`.